### PR TITLE
Remove side-effects from CCB value parser

### DIFF
--- a/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
+++ b/cocos/editor-support/cocosbuilder/CCNodeLoader.cpp
@@ -382,7 +382,6 @@ Vec2 NodeLoader::parsePropTypePosition(Node * pNode, Node * pParent, CCBReader *
     Size containerSize = ccbReader->getAnimationManager()->getContainerSize(pParent);
     
     Vec2 pt = getAbsolutePosition(Vec2(x,y), type, containerSize, pPropertyName);
-    pNode->setPosition(pt);
     
     if (ccbReader->getAnimatedProperties()->find(pPropertyName) != ccbReader->getAnimatedProperties()->end())
     {
@@ -485,8 +484,6 @@ float * NodeLoader::parsePropTypeScaleLock(Node * pNode, Node * /*pParent*/, CCB
     float y = ccbReader->readFloat();
     
     CCBReader::ScaleType type = static_cast<CCBReader::ScaleType>(ccbReader->readInt(false));
-    
-    setRelativeScale(pNode, x, y, type, pPropertyName);
     
     if (ccbReader->getAnimatedProperties()->find(pPropertyName) != ccbReader->getAnimatedProperties()->end())
     {


### PR DESCRIPTION
The parsing of position and scale have some side effects: instead of just parsing the value and returning it so it can be applied later (like the rest of parse methods do), these also actually set the values.
It seems to be redundant because just after the parsing is done, the actual functions that apply the values are called. In addition, it has the undesired side effect that if a custom loader wants to ignore the parsed values, it can't be achieved because the values are already applied when the loader gets them.
This PR just removes these extra applications.